### PR TITLE
Add ingredient model and YAML integration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module executive-chef
 
 go 1.24.3
 
-require github.com/charmbracelet/bubbletea v1.3.6
+require (
+	github.com/charmbracelet/bubbletea v1.3.6
+	gopkg.in/yaml.v3 v3.0.1
+)
 
 require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -43,3 +43,7 @@ golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
 golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/text v0.3.8 h1:nAL+RVCQ9uMn3vJZbV+MRnydTJFPf8qqY42YiA6MrqY=
 golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/ingredients.yaml
+++ b/ingredients.yaml
@@ -1,0 +1,6 @@
+- name: Chicken
+  role: Protein
+- name: Rice
+  role: Carb
+- name: Broccoli
+  role: Vegetable

--- a/internal/ingredient/ingredient.go
+++ b/internal/ingredient/ingredient.go
@@ -1,0 +1,36 @@
+package ingredient
+
+import (
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Role represents the role of an ingredient in a dish.
+type Role string
+
+const (
+	Protein   Role = "Protein"
+	Carb      Role = "Carb"
+	Vegetable Role = "Vegetable"
+)
+
+// Ingredient represents a single ingredient with a name and role.
+type Ingredient struct {
+	Name string `yaml:"name"`
+	Role Role   `yaml:"role"`
+}
+
+// LoadFromFile reads ingredients from a YAML file at the given path.
+func LoadFromFile(path string) ([]Ingredient, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var ingredients []Ingredient
+	if err := yaml.Unmarshal(data, &ingredients); err != nil {
+		return nil, err
+	}
+	return ingredients, nil
+}

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -1,8 +1,16 @@
 package ui
 
-import tea "github.com/charmbracelet/bubbletea"
+import (
+	"fmt"
 
-type model struct{}
+	tea "github.com/charmbracelet/bubbletea"
+
+	"executive-chef/internal/ingredient"
+)
+
+type model struct {
+	ingredients []ingredient.Ingredient
+}
 
 func (m model) Init() tea.Cmd { return nil }
 
@@ -16,11 +24,15 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m model) View() string {
-	return "Welcome to Executive Chef\n"
+	s := "Ingredients:\n"
+	for _, ing := range m.ingredients {
+		s += fmt.Sprintf("- %s (%s)\n", ing.Name, ing.Role)
+	}
+	return s
 }
 
-func Run() error {
-	p := tea.NewProgram(model{})
+func Run(ingredients []ingredient.Ingredient) error {
+	p := tea.NewProgram(model{ingredients: ingredients})
 	_, err := p.Run()
 	return err
 }

--- a/main.go
+++ b/main.go
@@ -3,11 +3,17 @@ package main
 import (
 	"log"
 
+	"executive-chef/internal/ingredient"
 	"executive-chef/internal/ui"
 )
 
 func main() {
-	if err := ui.Run(); err != nil {
+	ingredients, err := ingredient.LoadFromFile("ingredients.yaml")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := ui.Run(ingredients); err != nil {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
## Summary
- add Ingredient model with role enum and YAML loader
- load ingredient data at startup and render in the TUI

## Testing
- `go vet ./...`
- `go test ./...`
- `go run .`

------
https://chatgpt.com/codex/tasks/task_e_689fd5eb4630832cb304a93fc238fe4a