### PR TITLE
feat: add draft and hand panes to TUI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,13 @@ go 1.24.3
 
 require (
 	github.com/charmbracelet/bubbletea v1.3.6
+	github.com/charmbracelet/lipgloss v1.1.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
-	github.com/charmbracelet/lipgloss v1.1.0 // indirect
 	github.com/charmbracelet/x/ansi v0.9.3 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -4,35 +4,84 @@ import (
 	"fmt"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 
 	"executive-chef/internal/ingredient"
 )
 
 type model struct {
-	ingredients []ingredient.Ingredient
+	draft  []ingredient.Ingredient
+	hand   []ingredient.Ingredient
+	cursor int
+}
+
+func initialModel(ingredients []ingredient.Ingredient) model {
+	return model{draft: ingredients}
 }
 
 func (m model) Init() tea.Cmd { return nil }
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	if key, ok := msg.(tea.KeyMsg); ok {
-		if key.String() == "ctrl+c" || key.String() == "q" {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c", "q":
 			return m, tea.Quit
+		case "up", "k":
+			if m.cursor > 0 {
+				m.cursor--
+			}
+		case "down", "j":
+			if m.cursor < len(m.draft)-1 {
+				m.cursor++
+			}
+		case "enter", " ":
+			if len(m.draft) > 0 {
+				selected := m.draft[m.cursor]
+				m.hand = append(m.hand, selected)
+				m.draft = append(m.draft[:m.cursor], m.draft[m.cursor+1:]...)
+				if m.cursor >= len(m.draft) && m.cursor > 0 {
+					m.cursor--
+				}
+			}
 		}
 	}
 	return m, nil
 }
 
+var (
+	titleStyle = lipgloss.NewStyle().Bold(true)
+	paneStyle  = lipgloss.NewStyle().Padding(0, 1)
+)
+
 func (m model) View() string {
-	s := "Ingredients:\n"
-	for _, ing := range m.ingredients {
-		s += fmt.Sprintf("- %s (%s)\n", ing.Name, ing.Role)
+	draftView := titleStyle.Render("Draftable Ingredients:") + "\n"
+	for i, ing := range m.draft {
+		cursor := " "
+		if m.cursor == i {
+			cursor = ">"
+		}
+		draftView += fmt.Sprintf("%s %s (%s)\n", cursor, ing.Name, ing.Role)
 	}
-	return s
+
+	handView := titleStyle.Render("Your Hand:") + "\n"
+	if len(m.hand) == 0 {
+		handView += " (empty)\n"
+	} else {
+		for _, ing := range m.hand {
+			handView += fmt.Sprintf("- %s (%s)\n", ing.Name, ing.Role)
+		}
+	}
+
+	return lipgloss.JoinHorizontal(
+		lipgloss.Top,
+		paneStyle.Render(draftView),
+		paneStyle.Render(handView),
+	)
 }
 
 func Run(ingredients []ingredient.Ingredient) error {
-	p := tea.NewProgram(model{ingredients: ingredients})
+	p := tea.NewProgram(initialModel(ingredients), tea.WithAltScreen())
 	_, err := p.Run()
 	return err
 }


### PR DESCRIPTION
## Summary
- build a persistent TUI with separate panes for draftable ingredients and the player's hand
- allow selecting ingredients to move them from the draft list into the player's hand
- add lipgloss dependency for layout styling

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689fdaefaef8832ca09e418dca6b41b4