### PR TITLE
Add design phase with dish creation

### DIFF
--- a/internal/dish/dish.go
+++ b/internal/dish/dish.go
@@ -1,0 +1,9 @@
+package dish
+
+import "executive-chef/internal/ingredient"
+
+// Dish represents a named combination of ingredients.
+type Dish struct {
+	Name        string
+	Ingredients []ingredient.Ingredient
+}

--- a/internal/player/player.go
+++ b/internal/player/player.go
@@ -1,18 +1,27 @@
 package player
 
-import "executive-chef/internal/ingredient"
+import (
+	"executive-chef/internal/dish"
+	"executive-chef/internal/ingredient"
+)
 
-// Player represents a game participant who drafts ingredients.
+// Player represents a game participant who drafts ingredients and designs dishes.
 type Player struct {
 	Drafted []ingredient.Ingredient
+	Dishes  []dish.Dish
 }
 
-// New creates a player with an empty drafted list.
+// New creates a player with empty drafted and dish lists.
 func New() *Player {
-	return &Player{Drafted: []ingredient.Ingredient{}}
+	return &Player{Drafted: []ingredient.Ingredient{}, Dishes: []dish.Dish{}}
 }
 
 // Add adds an ingredient to the player's drafted list.
 func (p *Player) Add(ing ingredient.Ingredient) {
 	p.Drafted = append(p.Drafted, ing)
+}
+
+// AddDish adds a dish to the player's designed dishes.
+func (p *Player) AddDish(d dish.Dish) {
+	p.Dishes = append(p.Dishes, d)
 }

--- a/main.go
+++ b/main.go
@@ -1,13 +1,13 @@
 package main
 
 import (
+	"fmt"
 	"log"
 
 	"executive-chef/internal/deck"
 	"executive-chef/internal/game"
 	"executive-chef/internal/ingredient"
 	"executive-chef/internal/player"
-	"executive-chef/internal/ui"
 )
 
 func main() {
@@ -21,8 +21,17 @@ func main() {
 
 	t := game.Turn{Deck: d, Player: p}
 	t.DraftPhase()
+	t.DesignPhase()
 
-	if err := ui.Run(p.Drafted); err != nil {
-		log.Fatal(err)
+	fmt.Println("Your Dishes:")
+	for _, dish := range p.Dishes {
+		fmt.Printf("- %s: ", dish.Name)
+		for i, ing := range dish.Ingredients {
+			if i > 0 {
+				fmt.Print(", ")
+			}
+			fmt.Print(ing.Name)
+		}
+		fmt.Println()
 	}
 }


### PR DESCRIPTION
## Summary
- Introduce dishes as named combinations of ingredients
- Allow player to design dishes after drafting three ingredients
- Track and display created dishes

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_689fe01acf10832cafe0aba376816978