### PR TITLE
refactor: decouple game logic from UI

### DIFF
--- a/internal/game/events.go
+++ b/internal/game/events.go
@@ -1,0 +1,58 @@
+package game
+
+import (
+	"executive-chef/internal/dish"
+	"executive-chef/internal/ingredient"
+)
+
+// Event represents something that happened in the game and should be rendered by the UI.
+type Event interface {
+	EventType() string
+}
+
+// DraftOptionsEvent is sent when a new set of draftable ingredients should be shown.
+type DraftOptionsEvent struct {
+	Reveal []ingredient.Ingredient
+	Picks  int
+}
+
+func (e DraftOptionsEvent) EventType() string { return "draft_options" }
+
+// DesignOptionsEvent is sent when the player can design dishes from drafted ingredients.
+type DesignOptionsEvent struct {
+	Drafted []ingredient.Ingredient
+}
+
+func (e DesignOptionsEvent) EventType() string { return "design_options" }
+
+// DishCreatedEvent notifies the UI that a dish has been created.
+type DishCreatedEvent struct {
+	Dish dish.Dish
+}
+
+func (e DishCreatedEvent) EventType() string { return "dish_created" }
+
+// Action represents an input from the player relayed by the UI.
+type Action interface {
+	ActionType() string
+}
+
+// DraftSelectionAction is sent by the UI when the player selects an ingredient during drafting.
+type DraftSelectionAction struct {
+	Index int
+}
+
+func (a DraftSelectionAction) ActionType() string { return "draft_selection" }
+
+// CreateDishAction contains information to create a new dish.
+type CreateDishAction struct {
+	Name    string
+	Indices []int
+}
+
+func (a CreateDishAction) ActionType() string { return "create_dish" }
+
+// FinishDesignAction signals that the player is done designing dishes.
+type FinishDesignAction struct{}
+
+func (a FinishDesignAction) ActionType() string { return "finish_design" }

--- a/internal/game/turn.go
+++ b/internal/game/turn.go
@@ -1,12 +1,6 @@
 package game
 
 import (
-	"bufio"
-	"fmt"
-	"os"
-	"strconv"
-	"strings"
-
 	"executive-chef/internal/deck"
 	"executive-chef/internal/dish"
 	"executive-chef/internal/ingredient"
@@ -15,78 +9,64 @@ import (
 
 // Turn represents a single turn in the game.
 type Turn struct {
-	Deck   *deck.Deck
-	Player *player.Player
+	Deck    *deck.Deck
+	Player  *player.Player
+	Events  chan<- Event
+	Actions <-chan Action
 }
 
 // DraftPhase performs the drafting phase of a turn. Ten cards are revealed
 // and the player may draft three of them.
 func (t *Turn) DraftPhase() {
 	reveal := t.Deck.Draw(10)
-	reader := bufio.NewReader(os.Stdin)
-	for picks := 0; picks < 3 && len(reveal) > 0; picks++ {
-		fmt.Println("Choose an ingredient to draft:")
-		for i, card := range reveal {
-			fmt.Printf("%d) %s (%s)\n", i+1, card.Name, card.Role)
-		}
-		fmt.Print("Selection: ")
-		input, _ := reader.ReadString('\n')
-		n, err := strconv.Atoi(strings.TrimSpace(input))
-		if err != nil || n < 1 || n > len(reveal) {
-			fmt.Println("Invalid selection")
-			picks--
+	remaining := 3
+	t.Events <- DraftOptionsEvent{Reveal: reveal, Picks: remaining}
+	for remaining > 0 && len(reveal) > 0 {
+		act := <-t.Actions
+		sel, ok := act.(DraftSelectionAction)
+		if !ok || sel.Index < 0 || sel.Index >= len(reveal) {
 			continue
 		}
-		chosen := reveal[n-1]
+		chosen := reveal[sel.Index]
 		t.Player.Add(chosen)
-		reveal = append(reveal[:n-1], reveal[n:]...)
+		reveal = append(reveal[:sel.Index], reveal[sel.Index+1:]...)
+		remaining--
+		if remaining > 0 && len(reveal) > 0 {
+			t.Events <- DraftOptionsEvent{Reveal: reveal, Picks: remaining}
+		}
 	}
 }
 
 // DesignPhase allows the player to combine drafted ingredients into named dishes.
-// The player can create multiple dishes until they enter "done" as the dish name.
+// The player can create multiple dishes until a FinishDesignAction is received.
 func (t *Turn) DesignPhase() {
-	reader := bufio.NewReader(os.Stdin)
+	t.Events <- DesignOptionsEvent{Drafted: t.Player.Drafted}
 	for {
-		fmt.Print("Enter dish name (or 'done' to finish): ")
-		name, _ := reader.ReadString('\n')
-		name = strings.TrimSpace(name)
-		if strings.EqualFold(name, "done") || name == "" {
-			break
-		}
-
-		if len(t.Player.Drafted) == 0 {
-			fmt.Println("No ingredients available to create dishes.")
-			break
-		}
-
-		fmt.Println("Available ingredients:")
-		for i, ing := range t.Player.Drafted {
-			fmt.Printf("%d) %s (%s)\n", i+1, ing.Name, ing.Role)
-		}
-		fmt.Print("Choose ingredient numbers separated by spaces: ")
-		input, _ := reader.ReadString('\n')
-		fields := strings.Fields(input)
-
-		var dishIngs []ingredient.Ingredient
-		used := make(map[int]bool)
-		valid := true
-		for _, f := range fields {
-			idx, err := strconv.Atoi(f)
-			if err != nil || idx < 1 || idx > len(t.Player.Drafted) || used[idx] {
-				fmt.Println("Invalid ingredient selection.")
-				valid = false
-				break
+		act := <-t.Actions
+		switch a := act.(type) {
+		case CreateDishAction:
+			if a.Name == "" {
+				continue
 			}
-			used[idx] = true
-			dishIngs = append(dishIngs, t.Player.Drafted[idx-1])
+			used := make(map[int]bool)
+			var dishIngs []ingredient.Ingredient
+			valid := true
+			for _, idx := range a.Indices {
+				if idx < 0 || idx >= len(t.Player.Drafted) || used[idx] {
+					valid = false
+					break
+				}
+				used[idx] = true
+				dishIngs = append(dishIngs, t.Player.Drafted[idx])
+			}
+			if !valid || len(dishIngs) == 0 {
+				continue
+			}
+			d := dish.Dish{Name: a.Name, Ingredients: dishIngs}
+			t.Player.AddDish(d)
+			t.Events <- DishCreatedEvent{Dish: d}
+		case FinishDesignAction:
+			return
 		}
-		if !valid || len(dishIngs) == 0 {
-			fmt.Println("No dish created.")
-			continue
-		}
-
-		t.Player.AddDish(dish.Dish{Name: name, Ingredients: dishIngs})
-		fmt.Printf("Added dish '%s'!\n", name)
 	}
 }

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -1,28 +1,40 @@
 package ui
 
 import (
+	"bufio"
 	"fmt"
+	"os"
+	"strconv"
+	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
+	"executive-chef/internal/game"
 	"executive-chef/internal/ingredient"
 )
 
 type model struct {
-	draft  []ingredient.Ingredient
-	hand   []ingredient.Ingredient
-	cursor int
+	draft   []ingredient.Ingredient
+	cursor  int
+	actions chan<- game.Action
 }
 
-func initialModel(ingredients []ingredient.Ingredient) model {
-	return model{draft: ingredients}
+func initialModel(actions chan<- game.Action) model {
+	return model{actions: actions}
 }
 
 func (m model) Init() tea.Cmd { return nil }
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
+	case game.DraftOptionsEvent:
+		m.draft = msg.Reveal
+		if m.cursor >= len(m.draft) {
+			m.cursor = len(m.draft) - 1
+		}
+	case game.DesignOptionsEvent:
+		return m, tea.Quit
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "ctrl+c", "q":
@@ -37,12 +49,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		case "enter", " ":
 			if len(m.draft) > 0 {
-				selected := m.draft[m.cursor]
-				m.hand = append(m.hand, selected)
-				m.draft = append(m.draft[:m.cursor], m.draft[m.cursor+1:]...)
-				if m.cursor >= len(m.draft) && m.cursor > 0 {
-					m.cursor--
-				}
+				m.actions <- game.DraftSelectionAction{Index: m.cursor}
 			}
 		}
 	}
@@ -63,25 +70,76 @@ func (m model) View() string {
 		}
 		draftView += fmt.Sprintf("%s %s (%s)\n", cursor, ing.Name, ing.Role)
 	}
-
-	handView := titleStyle.Render("Your Hand:") + "\n"
-	if len(m.hand) == 0 {
-		handView += " (empty)\n"
-	} else {
-		for _, ing := range m.hand {
-			handView += fmt.Sprintf("- %s (%s)\n", ing.Name, ing.Role)
-		}
-	}
-
 	return lipgloss.JoinHorizontal(
 		lipgloss.Top,
 		paneStyle.Render(draftView),
-		paneStyle.Render(handView),
 	)
 }
 
-func Run(ingredients []ingredient.Ingredient) error {
-	p := tea.NewProgram(initialModel(ingredients), tea.WithAltScreen())
-	_, err := p.Run()
-	return err
+// Run renders game events and sends player actions back to the game.
+func Run(events <-chan game.Event, actions chan<- game.Action) error {
+	m := initialModel(actions)
+	p := tea.NewProgram(m, tea.WithAltScreen())
+
+	designEventCh := make(chan game.DesignOptionsEvent, 1)
+
+	go func() {
+		for e := range events {
+			if de, ok := e.(game.DesignOptionsEvent); ok {
+				designEventCh <- de
+				p.Send(e)
+				p.Quit()
+				return
+			}
+			p.Send(e)
+		}
+	}()
+
+	if _, err := p.Run(); err != nil {
+		return err
+	}
+
+	var design game.DesignOptionsEvent
+	select {
+	case design = <-designEventCh:
+	default:
+		return nil
+	}
+
+	reader := bufio.NewReader(os.Stdin)
+	for {
+		fmt.Print("Enter dish name (or 'done' to finish): ")
+		name, _ := reader.ReadString('\n')
+		name = strings.TrimSpace(name)
+		if strings.EqualFold(name, "done") || name == "" {
+			actions <- game.FinishDesignAction{}
+			return nil
+		}
+		fmt.Println("Available ingredients:")
+		for i, ing := range design.Drafted {
+			fmt.Printf("%d) %s (%s)\n", i+1, ing.Name, ing.Role)
+		}
+		fmt.Print("Choose ingredient numbers separated by spaces: ")
+		input, _ := reader.ReadString('\n')
+		fields := strings.Fields(input)
+		var indices []int
+		for _, f := range fields {
+			idx, err := strconv.Atoi(f)
+			if err != nil || idx < 1 || idx > len(design.Drafted) {
+				indices = nil
+				break
+			}
+			indices = append(indices, idx-1)
+		}
+		if len(indices) == 0 {
+			fmt.Println("Invalid selection.")
+			continue
+		}
+		actions <- game.CreateDishAction{Name: name, Indices: indices}
+		if evt, ok := <-events; ok {
+			if created, ok := evt.(game.DishCreatedEvent); ok {
+				fmt.Printf("Added dish '%s'!\n", created.Dish.Name)
+			}
+		}
+	}
 }

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"executive-chef/internal/game"
 	"executive-chef/internal/ingredient"
 	"executive-chef/internal/player"
+	"executive-chef/internal/ui"
 )
 
 func main() {
@@ -19,9 +20,20 @@ func main() {
 	d := deck.New(ingredients)
 	p := player.New()
 
-	t := game.Turn{Deck: d, Player: p}
-	t.DraftPhase()
-	t.DesignPhase()
+	events := make(chan game.Event)
+	actions := make(chan game.Action)
+
+	t := game.Turn{Deck: d, Player: p, Events: events, Actions: actions}
+
+	go func() {
+		t.DraftPhase()
+		t.DesignPhase()
+		close(events)
+	}()
+
+	if err := ui.Run(events, actions); err != nil {
+		log.Fatal(err)
+	}
 
 	fmt.Println("Your Dishes:")
 	for _, dish := range p.Dishes {


### PR DESCRIPTION
## Summary
- introduce event and action types to communicate between game logic and UI
- refactor Turn to emit events and consume actions via channels
- update TUI to render events and send user input back to the game
- wire channels in `main` to run game loop and UI concurrently

## Testing
- `go test ./...`
- `go vet ./... && echo vet-ok`


------
https://chatgpt.com/codex/tasks/task_e_689fe65accf0832cad17adab318967a7