### PR TITLE
feat(ui): add persistent design mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS
+
+## Architecture Overview
+
+This project implements a small drafting game.
+
+- **Game Core** (`internal/game`)
+  - `Turn` orchestrates the two main phases:
+    - **Draft phase**: the deck reveals ingredients and the player drafts a subset.
+    - **Design phase**: the player combines drafted ingredients into dishes.
+  - Events and actions are exchanged with the UI through channels.
+
+- **Domain Packages** (`internal/ingredient`, `internal/dish`, `internal/player`, etc.)
+  encapsulate gameplay entities.
+
+## UI
+
+- The terminal UI lives in `internal/ui` and is built with
+  [Bubble Tea](https://github.com/charmbracelet/bubbletea).
+- The UI runs in a single persistent program and is divided into **modes**.
+  Each mode handles rendering and input for a game phase.
+    - `draftMode`: displays revealed ingredients and lets the player choose picks.
+    - `designMode`: shows drafted ingredients, lets the player name dishes,
+      select ingredients, and finish designing.
+- Game events are sent to the UI program via a channel, and player actions are
+  sent back to the game through another channel.
+
+## Checks
+
+Run the following to verify changes compile:
+
+```bash
+go mod tidy
+go build ./...
+```

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,14 @@ module executive-chef
 go 1.24.3
 
 require (
+	github.com/charmbracelet/bubbles v0.17.1
 	github.com/charmbracelet/bubbletea v1.3.6
 	github.com/charmbracelet/lipgloss v1.1.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
+	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/x/ansi v0.9.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
+github.com/charmbracelet/bubbles v0.17.1 h1:0SIyjOnkrsfDo88YvPgAWvZMwXe26TP6drRvmkjyUu4=
+github.com/charmbracelet/bubbles v0.17.1/go.mod h1:9HxZWlkCqz2PRwsCbYl7a3KXvGzFaDHpYbSYMJ+nE3o=
 github.com/charmbracelet/bubbletea v1.3.6 h1:VkHIxPJQeDt0aFJIsVxw8BQdh/F/L2KKZGsK6et5taU=
 github.com/charmbracelet/bubbletea v1.3.6/go.mod h1:oQD9VCRQFF8KplacJLo28/jofOI2ToOfGYeFgBBxHOc=
 github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc h1:4pZI35227imm7yK2bGPcfpFEmuY1gc2YSTShr4iJBfs=

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -1,12 +1,10 @@
 package ui
 
 import (
-	"bufio"
 	"fmt"
-	"os"
-	"strconv"
 	"strings"
 
+	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
@@ -14,46 +12,176 @@ import (
 	"executive-chef/internal/ingredient"
 )
 
+// uiMode represents a UI mode for a game phase.
+type uiMode interface {
+	Init(*model) tea.Cmd
+	Update(*model, tea.Msg) (uiMode, tea.Cmd)
+	View(*model) string
+}
+
 type model struct {
-	draft   []ingredient.Ingredient
-	cursor  int
 	actions chan<- game.Action
+	mode    uiMode
 }
 
-func initialModel(actions chan<- game.Action) model {
-	return model{actions: actions}
+func initialModel(actions chan<- game.Action) *model {
+	m := &model{actions: actions}
+	m.mode = &draftMode{}
+	return m
 }
 
-func (m model) Init() tea.Cmd { return nil }
+func (m *model) Init() tea.Cmd {
+	return m.mode.Init(m)
+}
 
-func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if newMode, cmd := m.mode.Update(m, msg); newMode != nil {
+		m.mode = newMode
+		initCmd := m.mode.Init(m)
+		return m, tea.Batch(cmd, initCmd)
+	} else {
+		return m, cmd
+	}
+}
+
+func (m *model) View() string {
+	return m.mode.View(m)
+}
+
+// ---- Draft Mode ----
+type draftMode struct {
+	draft  []ingredient.Ingredient
+	cursor int
+}
+
+func (d *draftMode) Init(m *model) tea.Cmd { return nil }
+
+func (d *draftMode) Update(m *model, msg tea.Msg) (uiMode, tea.Cmd) {
 	switch msg := msg.(type) {
 	case game.DraftOptionsEvent:
-		m.draft = msg.Reveal
-		if m.cursor >= len(m.draft) {
-			m.cursor = len(m.draft) - 1
+		d.draft = msg.Reveal
+		if d.cursor >= len(d.draft) {
+			d.cursor = len(d.draft) - 1
 		}
 	case game.DesignOptionsEvent:
-		return m, tea.Quit
+		return &designMode{drafted: msg.Drafted}, nil
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "ctrl+c", "q":
-			return m, tea.Quit
+			return nil, tea.Quit
 		case "up", "k":
-			if m.cursor > 0 {
-				m.cursor--
+			if d.cursor > 0 {
+				d.cursor--
 			}
 		case "down", "j":
-			if m.cursor < len(m.draft)-1 {
-				m.cursor++
+			if d.cursor < len(d.draft)-1 {
+				d.cursor++
 			}
 		case "enter", " ":
-			if len(m.draft) > 0 {
-				m.actions <- game.DraftSelectionAction{Index: m.cursor}
+			if len(d.draft) > 0 {
+				m.actions <- game.DraftSelectionAction{Index: d.cursor}
 			}
 		}
 	}
-	return m, nil
+	return nil, nil
+}
+
+func (d *draftMode) View(m *model) string {
+	var b strings.Builder
+	b.WriteString(titleStyle.Render("Draftable Ingredients:") + "\n")
+	for i, ing := range d.draft {
+		cursor := " "
+		if d.cursor == i {
+			cursor = ">"
+		}
+		b.WriteString(fmt.Sprintf("%s %s (%s)\n", cursor, ing.Name, ing.Role))
+	}
+	return paneStyle.Render(b.String())
+}
+
+// ---- Design Mode ----
+type designMode struct {
+	drafted  []ingredient.Ingredient
+	cursor   int
+	selected map[int]bool
+	name     textinput.Model
+	message  string
+}
+
+func (d *designMode) Init(m *model) tea.Cmd {
+	d.selected = make(map[int]bool)
+	d.name = textinput.New()
+	d.name.Placeholder = "Dish name"
+	d.name.Focus()
+	return nil
+}
+
+func (d *designMode) Update(m *model, msg tea.Msg) (uiMode, tea.Cmd) {
+	var cmd tea.Cmd
+	d.name, cmd = d.name.Update(msg)
+	switch msg := msg.(type) {
+	case game.DishCreatedEvent:
+		d.message = fmt.Sprintf("Added dish '%s'!", msg.Dish.Name)
+		d.name.SetValue("")
+		d.selected = make(map[int]bool)
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c", "q":
+			m.actions <- game.FinishDesignAction{}
+			return nil, tea.Quit
+		case "up", "k":
+			if d.cursor > 0 {
+				d.cursor--
+			}
+		case "down", "j":
+			if d.cursor < len(d.drafted)-1 {
+				d.cursor++
+			}
+		case " ":
+			if d.selected[d.cursor] {
+				delete(d.selected, d.cursor)
+			} else {
+				d.selected[d.cursor] = true
+			}
+		case "enter":
+			name := strings.TrimSpace(d.name.Value())
+			if name != "" && len(d.selected) > 0 {
+				var indices []int
+				for i := range d.drafted {
+					if d.selected[i] {
+						indices = append(indices, i)
+					}
+				}
+				m.actions <- game.CreateDishAction{Name: name, Indices: indices}
+			}
+		case "f":
+			m.actions <- game.FinishDesignAction{}
+			return nil, tea.Quit
+		}
+	}
+	return nil, cmd
+}
+
+func (d *designMode) View(m *model) string {
+	var b strings.Builder
+	b.WriteString(titleStyle.Render("Design Dishes") + "\n")
+	for i, ing := range d.drafted {
+		cursor := " "
+		if d.cursor == i {
+			cursor = ">"
+		}
+		mark := " "
+		if d.selected[i] {
+			mark = "*"
+		}
+		b.WriteString(fmt.Sprintf("%s%s %s (%s)\n", cursor, mark, ing.Name, ing.Role))
+	}
+	b.WriteString("\n" + d.name.View() + "\n")
+	if d.message != "" {
+		b.WriteString(d.message + "\n")
+	}
+	b.WriteString("\nspace: select • enter: create dish • f: finish\n")
+	return paneStyle.Render(b.String())
 }
 
 var (
@@ -61,85 +189,17 @@ var (
 	paneStyle  = lipgloss.NewStyle().Padding(0, 1)
 )
 
-func (m model) View() string {
-	draftView := titleStyle.Render("Draftable Ingredients:") + "\n"
-	for i, ing := range m.draft {
-		cursor := " "
-		if m.cursor == i {
-			cursor = ">"
-		}
-		draftView += fmt.Sprintf("%s %s (%s)\n", cursor, ing.Name, ing.Role)
-	}
-	return lipgloss.JoinHorizontal(
-		lipgloss.Top,
-		paneStyle.Render(draftView),
-	)
-}
-
 // Run renders game events and sends player actions back to the game.
 func Run(events <-chan game.Event, actions chan<- game.Action) error {
 	m := initialModel(actions)
 	p := tea.NewProgram(m, tea.WithAltScreen())
 
-	designEventCh := make(chan game.DesignOptionsEvent, 1)
-
 	go func() {
 		for e := range events {
-			if de, ok := e.(game.DesignOptionsEvent); ok {
-				designEventCh <- de
-				p.Send(e)
-				p.Quit()
-				return
-			}
 			p.Send(e)
 		}
 	}()
 
-	if _, err := p.Run(); err != nil {
-		return err
-	}
-
-	var design game.DesignOptionsEvent
-	select {
-	case design = <-designEventCh:
-	default:
-		return nil
-	}
-
-	reader := bufio.NewReader(os.Stdin)
-	for {
-		fmt.Print("Enter dish name (or 'done' to finish): ")
-		name, _ := reader.ReadString('\n')
-		name = strings.TrimSpace(name)
-		if strings.EqualFold(name, "done") || name == "" {
-			actions <- game.FinishDesignAction{}
-			return nil
-		}
-		fmt.Println("Available ingredients:")
-		for i, ing := range design.Drafted {
-			fmt.Printf("%d) %s (%s)\n", i+1, ing.Name, ing.Role)
-		}
-		fmt.Print("Choose ingredient numbers separated by spaces: ")
-		input, _ := reader.ReadString('\n')
-		fields := strings.Fields(input)
-		var indices []int
-		for _, f := range fields {
-			idx, err := strconv.Atoi(f)
-			if err != nil || idx < 1 || idx > len(design.Drafted) {
-				indices = nil
-				break
-			}
-			indices = append(indices, idx-1)
-		}
-		if len(indices) == 0 {
-			fmt.Println("Invalid selection.")
-			continue
-		}
-		actions <- game.CreateDishAction{Name: name, Indices: indices}
-		if evt, ok := <-events; ok {
-			if created, ok := evt.(game.DishCreatedEvent); ok {
-				fmt.Printf("Added dish '%s'!\n", created.Dish.Name)
-			}
-		}
-	}
+	_, err := p.Run()
+	return err
 }


### PR DESCRIPTION
## Summary
- describe game and UI architecture in new AGENTS.md
- refactor TUI to use draft and design modes with persistent Bubble Tea program
- add bubbles dependency for text input

## Testing
- `go mod tidy`
- `go build -v ./...`


------
https://chatgpt.com/codex/tasks/task_e_689fe8aa00ac832cbc49d7d05ac40294