### PR TITLE
Limit dishes and display created names

### DIFF
--- a/internal/game/turn.go
+++ b/internal/game/turn.go
@@ -45,7 +45,7 @@ func (t *Turn) DesignPhase() {
 		act := <-t.Actions
 		switch a := act.(type) {
 		case CreateDishAction:
-			if a.Name == "" {
+			if len(t.Player.Dishes) >= 2 || a.Name == "" {
 				continue
 			}
 			used := make(map[int]bool)

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -106,6 +106,7 @@ type designMode struct {
 	selected map[int]bool
 	name     textinput.Model
 	message  string
+	dishes   []string
 }
 
 func (d *designMode) Init(m *model) tea.Cmd {
@@ -113,6 +114,7 @@ func (d *designMode) Init(m *model) tea.Cmd {
 	d.name = textinput.New()
 	d.name.Placeholder = "Dish name"
 	d.name.Focus()
+	d.dishes = []string{}
 	return nil
 }
 
@@ -121,6 +123,7 @@ func (d *designMode) Update(m *model, msg tea.Msg) (uiMode, tea.Cmd) {
 	d.name, cmd = d.name.Update(msg)
 	switch msg := msg.(type) {
 	case game.DishCreatedEvent:
+		d.dishes = append(d.dishes, msg.Dish.Name)
 		d.message = fmt.Sprintf("Added dish '%s'!", msg.Dish.Name)
 		d.name.SetValue("")
 		d.selected = make(map[int]bool)
@@ -145,6 +148,10 @@ func (d *designMode) Update(m *model, msg tea.Msg) (uiMode, tea.Cmd) {
 			}
 		case "enter":
 			name := strings.TrimSpace(d.name.Value())
+			if len(d.dishes) >= 2 {
+				d.message = "Maximum of 2 dishes reached"
+				break
+			}
 			if name != "" && len(d.selected) > 0 {
 				var indices []int
 				for i := range d.drafted {
@@ -175,6 +182,12 @@ func (d *designMode) View(m *model) string {
 			mark = "*"
 		}
 		b.WriteString(fmt.Sprintf("%s%s %s (%s)\n", cursor, mark, ing.Name, ing.Role))
+	}
+	if len(d.dishes) > 0 {
+		b.WriteString("\nDishes:\n")
+		for _, name := range d.dishes {
+			b.WriteString("- " + name + "\n")
+		}
 	}
 	b.WriteString("\n" + d.name.View() + "\n")
 	if d.message != "" {


### PR DESCRIPTION
## Summary
- Restrict game to creating only two dishes per turn
- Track and show names of all dishes while designing

## Testing
- `go mod tidy`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689febcf1468832cbb831116bf539b7d