### PR TITLE
Add random customer names to service mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module executive-chef
 go 1.24.3
 
 require (
+	github.com/brianvoe/gofakeit/v7 v7.3.0
 	github.com/charmbracelet/bubbles v0.17.1
 	github.com/charmbracelet/bubbletea v1.3.6
 	github.com/charmbracelet/lipgloss v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
+github.com/brianvoe/gofakeit/v7 v7.3.0 h1:TWStf7/lLpAjKw+bqwzeORo9jvrxToWEwp9b1J2vApQ=
+github.com/brianvoe/gofakeit/v7 v7.3.0/go.mod h1:QXuPeBw164PJCzCUZVmgpgHJ3Llj49jSLVkKPMtxtxA=
 github.com/charmbracelet/bubbles v0.17.1 h1:0SIyjOnkrsfDo88YvPgAWvZMwXe26TP6drRvmkjyUu4=
 github.com/charmbracelet/bubbles v0.17.1/go.mod h1:9HxZWlkCqz2PRwsCbYl7a3KXvGzFaDHpYbSYMJ+nE3o=
 github.com/charmbracelet/bubbletea v1.3.6 h1:VkHIxPJQeDt0aFJIsVxw8BQdh/F/L2KKZGsK6et5taU=

--- a/internal/customer/customer.go
+++ b/internal/customer/customer.go
@@ -1,10 +1,12 @@
 package customer
 
 import (
-	"math/rand"
-	"time"
+        "math/rand"
+        "time"
 
-	"executive-chef/internal/ingredient"
+        "github.com/brianvoe/gofakeit/v7"
+
+        "executive-chef/internal/ingredient"
 )
 
 // Craving represents a combination of ingredients a customer wants.
@@ -12,9 +14,10 @@ type Craving struct {
 	Ingredients []ingredient.Ingredient
 }
 
-// Customer represents a single customer with ordered cravings.
+// Customer represents a single customer with ordered cravings and a name.
 type Customer struct {
-	Cravings []Craving
+        Name     string
+        Cravings []Craving
 }
 
 // RandomCraving returns a Craving made of random ingredients.
@@ -37,11 +40,11 @@ func RandomCustomer(ingredients []ingredient.Ingredient, numCravings int) Custom
 	if numCravings <= 0 {
 		numCravings = 1
 	}
-	cravings := make([]Craving, numCravings)
-	for i := 0; i < numCravings; i++ {
-		cravings[i] = RandomCraving(ingredients)
-	}
-	return Customer{Cravings: cravings}
+        cravings := make([]Craving, numCravings)
+        for i := 0; i < numCravings; i++ {
+                cravings[i] = RandomCraving(ingredients)
+        }
+        return Customer{Name: gofakeit.Name(), Cravings: cravings}
 }
 
 // RandomCustomers generates the specified number of customers.
@@ -55,5 +58,6 @@ func RandomCustomers(ingredients []ingredient.Ingredient, count int) []Customer 
 }
 
 func init() {
-	rand.Seed(time.Now().UnixNano())
+        rand.Seed(time.Now().UnixNano())
+        gofakeit.Seed(time.Now().UnixNano())
 }

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -267,21 +267,21 @@ func (s *serviceMode) Update(m *model, msg tea.Msg) (uiMode, tea.Cmd) {
 func (s *serviceMode) View(m *model) string {
 	var b strings.Builder
 	b.WriteString(titleStyle.Render("Service Results") + "\n")
-	for _, r := range s.results {
-		var craving []string
-		if len(r.Customer.Cravings) > 0 {
-			for _, ing := range r.Customer.Cravings[0].Ingredients {
-				craving = append(craving, ing.Name)
-			}
-		}
-		b.WriteString(fmt.Sprintf("%s -> ", strings.Join(craving, ", ")))
-		if r.Dish != nil {
-			b.WriteString(r.Dish.Name)
-		} else {
-			b.WriteString("no dish")
-		}
-		b.WriteString("\n")
-	}
+        for _, r := range s.results {
+                var craving []string
+                if len(r.Customer.Cravings) > 0 {
+                        for _, ing := range r.Customer.Cravings[0].Ingredients {
+                                craving = append(craving, ing.Name)
+                        }
+                }
+                b.WriteString(fmt.Sprintf("%s: %s -> ", r.Customer.Name, strings.Join(craving, ", ")))
+                if r.Dish != nil {
+                        b.WriteString(r.Dish.Name)
+                } else {
+                        b.WriteString("no dish")
+                }
+                b.WriteString("\n")
+        }
 	if s.finished {
 		b.WriteString("\nPress q to quit\n")
 	}


### PR DESCRIPTION
## Summary
- Generate random customer names using gofakeit
- Display customer names alongside cravings in service results

## Testing
- `go mod tidy`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689fef79b9ac832c8fe85a530e7d97c2