### PR TITLE
Ensure quitting works in service phase

### DIFF
--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -48,13 +48,14 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var vpCmd tea.Cmd
 	m.vp, vpCmd = m.vp.Update(msg)
 
-	if newMode, cmd := m.mode.Update(m, msg); newMode != nil {
+	newMode, modeCmd := m.mode.Update(m, msg)
+	if newMode != nil {
 		m.mode = newMode
 		initCmd := m.mode.Init(m)
-		return m, tea.Batch(cmd, initCmd, vpCmd)
+		return m, tea.Batch(modeCmd, initCmd, vpCmd)
 	}
 
-	return m, tea.Batch(vpCmd)
+	return m, tea.Batch(vpCmd, modeCmd)
 }
 
 func (m *model) View() string {


### PR DESCRIPTION
## Summary
- ensure UI passes mode commands even without mode switches so `q` and `ctrl+c` quit as expected in service phase

## Testing
- `go mod tidy`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689ff012ee18832c970a9df537f540e0