### PR TITLE
Clarify draft event logging

### DIFF
--- a/internal/game/events.go
+++ b/internal/game/events.go
@@ -36,6 +36,13 @@ type DraftOptionsEvent struct {
 
 func (e DraftOptionsEvent) EventType() string { return "draft_options" }
 
+// IngredientDraftedEvent announces that an ingredient has been drafted by the player.
+type IngredientDraftedEvent struct {
+	Ingredient ingredient.Ingredient
+}
+
+func (e IngredientDraftedEvent) EventType() string { return "ingredient_drafted" }
+
 // DesignOptionsEvent is sent when the player can design dishes from drafted ingredients.
 type DesignOptionsEvent struct {
 	Drafted []ingredient.Ingredient

--- a/internal/game/turn.go
+++ b/internal/game/turn.go
@@ -32,6 +32,7 @@ func (t *Turn) DraftPhase() {
 		}
 		chosen := reveal[sel.Index]
 		t.Player.Add(chosen)
+		t.Events <- IngredientDraftedEvent{Ingredient: chosen}
 		reveal = append(reveal[:sel.Index], reveal[sel.Index+1:]...)
 		remaining--
 		if remaining > 0 && len(reveal) > 0 {

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -44,9 +44,11 @@ func (m *model) Init() tea.Cmd {
 
 func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if e, ok := msg.(game.Event); ok {
-		m.events = append(m.events, eventString(e))
-		m.vp.SetContent(strings.Join(m.events, "\n"))
-		m.vp.GotoBottom()
+		if str := eventString(e); str != "" {
+			m.events = append(m.events, str)
+			m.vp.SetContent(strings.Join(m.events, "\n"))
+			m.vp.GotoBottom()
+		}
 		if info, ok := e.(game.PhaseEvent); ok {
 			m.turn = info.Turn
 			m.phase = info.Phase
@@ -82,11 +84,12 @@ func eventString(e game.Event) string {
 	case game.PhaseEvent:
 		return fmt.Sprintf("Turn %d: %s phase", e.Turn, e.Phase)
 	case game.DraftOptionsEvent:
-		var names []string
-		for _, ing := range e.Reveal {
-			names = append(names, ing.Name)
+		if e.Picks == 3 {
+			return "Draft phase started"
 		}
-		return fmt.Sprintf("Draft: %s", strings.Join(names, ", "))
+		return ""
+	case game.IngredientDraftedEvent:
+		return fmt.Sprintf("Ingredient drafted: %s", e.Ingredient.Name)
 	case game.DesignOptionsEvent:
 		return "Design phase begins"
 	case game.DishCreatedEvent:


### PR DESCRIPTION
## Summary
- add `IngredientDraftedEvent` and emit it during drafting
- log only when draft phase begins or an ingredient is picked

## Testing
- `go mod tidy`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a0c4546174832ca525b4277f1a2d92