### PR TITLE
Persist dishes across turns and reset ingredients

### DIFF
--- a/internal/game/turn.go
+++ b/internal/game/turn.go
@@ -80,7 +80,12 @@ func (t *Turn) DesignPhase() {
 func (t *Turn) ServicePhase() {
 	t.Events <- PhaseEvent{Turn: t.Number, Phase: PhaseService}
 	customers := customer.RandomCustomers(t.Player.Drafted, 3)
-	available := append([]dish.Dish(nil), t.Player.Dishes...)
+	var available []dish.Dish
+	for _, d := range t.Player.Dishes {
+		if hasIngredients(t.Player.Drafted, d.Ingredients) {
+			available = append(available, d)
+		}
+	}
 	for i, c := range customers {
 		bestIdx := -1
 		bestScore := 0
@@ -126,4 +131,20 @@ func (t *Turn) ServicePhase() {
 			break
 		}
 	}
+}
+
+func hasIngredients(have []ingredient.Ingredient, needed []ingredient.Ingredient) bool {
+	for _, n := range needed {
+		found := false
+		for _, h := range have {
+			if h == n {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/player/player.go
+++ b/internal/player/player.go
@@ -26,8 +26,7 @@ func (p *Player) AddDish(d dish.Dish) {
 	p.Dishes = append(p.Dishes, d)
 }
 
-// ResetTurn clears drafted ingredients and dishes for a new turn.
+// ResetTurn clears drafted ingredients for a new turn while keeping dishes.
 func (p *Player) ResetTurn() {
 	p.Drafted = nil
-	p.Dishes = nil
 }

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -9,6 +9,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
+	"executive-chef/internal/dish"
 	"executive-chef/internal/game"
 	"executive-chef/internal/ingredient"
 )
@@ -23,12 +24,14 @@ type uiMode interface {
 }
 
 type model struct {
-	actions chan<- game.Action
-	mode    uiMode
-	events  []string
-	vp      viewport.Model
-	turn    int
-	phase   game.Phase
+	actions     chan<- game.Action
+	mode        uiMode
+	events      []string
+	vp          viewport.Model
+	turn        int
+	phase       game.Phase
+	dishes      []dish.Dish
+	ingredients []ingredient.Ingredient
 }
 
 func initialModel(actions chan<- game.Action) *model {
@@ -49,9 +52,16 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.vp.SetContent(strings.Join(m.events, "\n"))
 			m.vp.GotoBottom()
 		}
-		if info, ok := e.(game.PhaseEvent); ok {
-			m.turn = info.Turn
-			m.phase = info.Phase
+		switch ev := e.(type) {
+		case game.PhaseEvent:
+			m.turn = ev.Turn
+			m.phase = ev.Phase
+		case game.IngredientDraftedEvent:
+			m.ingredients = append(m.ingredients, ev.Ingredient)
+		case game.DishCreatedEvent:
+			m.dishes = append(m.dishes, ev.Dish)
+		case game.ServiceEndEvent:
+			m.ingredients = nil
 		}
 	}
 
@@ -71,12 +81,43 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m *model) View() string {
 	main := m.mode.View(m)
 
-	info := paneStyle.Render(titleStyle.Render("Game Info") + "\n" + fmt.Sprintf("Turn: %d\nPhase: %s", m.turn, m.phase))
+	var infoBuilder strings.Builder
+	infoBuilder.WriteString(titleStyle.Render("Game Info") + "\n")
+	infoBuilder.WriteString(fmt.Sprintf("Turn: %d\nPhase: %s\n", m.turn, m.phase))
+	infoBuilder.WriteString("Dishes:\n")
+	if len(m.dishes) == 0 {
+		infoBuilder.WriteString("  (none)\n")
+	} else {
+		for _, d := range m.dishes {
+			name := d.Name
+			if !m.hasIngredients(d) {
+				name = missingStyle.Render(name)
+			}
+			infoBuilder.WriteString("- " + name + "\n")
+		}
+	}
+	info := paneStyle.Render(infoBuilder.String())
 	logView := paneStyle.Render(titleStyle.Render("Events") + "\n" + m.vp.View())
 
 	content := lipgloss.JoinHorizontal(lipgloss.Top, main, logView)
 	status := statusStyle.Render(m.mode.Status(m))
 	return lipgloss.JoinVertical(lipgloss.Left, info, content, status)
+}
+
+func (m *model) hasIngredients(d dish.Dish) bool {
+	for _, need := range d.Ingredients {
+		found := false
+		for _, have := range m.ingredients {
+			if have == need {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
 }
 
 func eventString(e game.Event) string {
@@ -350,6 +391,7 @@ var (
 	titleStyle    = lipgloss.NewStyle().Bold(true)
 	paneStyle     = lipgloss.NewStyle().Padding(0, 1)
 	selectedStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#FFD700"))
+	missingStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("#FF0000"))
 	statusStyle   = lipgloss.NewStyle().Padding(0, 1)
 )
 


### PR DESCRIPTION
## Summary
- Keep player dishes across turns while clearing drafted ingredients
- Serve only dishes with available ingredients and show them in Game Info
- Display dish list in UI, highlighting missing ingredients in red

## Testing
- `go mod tidy`
- `go build -v ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a0c798699c832c94148b20c3ae6fb5