### PR TITLE
Require leaving name input before finishing design

### DIFF
--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -270,10 +270,12 @@ func (d *designMode) Update(m *model, msg tea.Msg) (uiMode, tea.Cmd) {
 				d.selecting = true
 				d.name.Blur()
 			}
-		case "f":
-			m.message = ""
-			m.actions <- game.FinishDesignAction{}
-			return nil, nil
+		case "f", "F":
+			if d.selecting {
+				m.message = ""
+				m.actions <- game.FinishDesignAction{}
+				return nil, nil
+			}
 		}
 	}
 	return nil, cmd


### PR DESCRIPTION
## Summary
- prevent finishing the design phase when typing a dish name

## Testing
- `go mod tidy`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a0c9088ea4832c87fd06474e26bc9d