### PR TITLE
Deplete ingredients after serving dishes

### DIFF
--- a/internal/game/turn.go
+++ b/internal/game/turn.go
@@ -120,6 +120,15 @@ func (t *Turn) ServicePhase() {
 			d := available[bestIdx]
 			chosen = &d
 			available = append(available[:bestIdx], available[bestIdx+1:]...)
+			t.Player.UseIngredients(d.Ingredients)
+			// Remove any dishes that can no longer be made with remaining ingredients.
+			filtered := available[:0]
+			for _, dish := range available {
+				if hasIngredients(t.Player.Drafted, dish.Ingredients) {
+					filtered = append(filtered, dish)
+				}
+			}
+			available = filtered
 			switch bestCraving {
 			case 0:
 				payment = 5

--- a/internal/player/player.go
+++ b/internal/player/player.go
@@ -27,6 +27,19 @@ func (p *Player) AddDish(d dish.Dish) {
 	p.Dishes = append(p.Dishes, d)
 }
 
+// UseIngredients removes the specified ingredients from the player's drafted list.
+// Each ingredient in the slice is removed once if present.
+func (p *Player) UseIngredients(ings []ingredient.Ingredient) {
+	for _, used := range ings {
+		for i, have := range p.Drafted {
+			if have == used {
+				p.Drafted = append(p.Drafted[:i], p.Drafted[i+1:]...)
+				break
+			}
+		}
+	}
+}
+
 // AddMoney increases the player's money by the given amount.
 func (p *Player) AddMoney(amount int) {
 	p.Money += amount


### PR DESCRIPTION
## Summary
- remove used ingredients from the player when a dish is served
- filter available dishes after serving to account for depleted ingredients

## Testing
- `go mod tidy`
- `go build ./... && echo build-ok`


------
https://chatgpt.com/codex/tasks/task_e_68a0cba2e1ac832c9facf31e32d4bba4