### PR TITLE
Allow creating two dishes per turn up to ten overall

### DIFF
--- a/internal/game/turn.go
+++ b/internal/game/turn.go
@@ -1,13 +1,13 @@
 package game
 
 import (
-        "sort"
+	"sort"
 
-        "executive-chef/internal/customer"
-        "executive-chef/internal/deck"
-        "executive-chef/internal/dish"
-        "executive-chef/internal/ingredient"
-        "executive-chef/internal/player"
+	"executive-chef/internal/customer"
+	"executive-chef/internal/deck"
+	"executive-chef/internal/dish"
+	"executive-chef/internal/ingredient"
+	"executive-chef/internal/player"
 )
 
 // Turn represents a single turn in the game.
@@ -22,23 +22,23 @@ type Turn struct {
 // DraftPhase performs the drafting phase of a turn. Ten cards are revealed
 // and the player may draft three of them.
 func (t *Turn) DraftPhase() {
-        t.Events <- PhaseEvent{Turn: t.Number, Phase: PhaseDraft}
-        reveal := t.Deck.Draw(10)
-        roleOrder := map[ingredient.Role]int{
-                ingredient.Protein:   0,
-                ingredient.Vegetable: 1,
-                ingredient.Carb:      2,
-        }
-        sort.Slice(reveal, func(i, j int) bool {
-                ri := roleOrder[reveal[i].Role]
-                rj := roleOrder[reveal[j].Role]
-                if ri != rj {
-                        return ri < rj
-                }
-                return reveal[i].Name < reveal[j].Name
-        })
-        remaining := 3
-        t.Events <- DraftOptionsEvent{Reveal: reveal, Picks: remaining}
+	t.Events <- PhaseEvent{Turn: t.Number, Phase: PhaseDraft}
+	reveal := t.Deck.Draw(10)
+	roleOrder := map[ingredient.Role]int{
+		ingredient.Protein:   0,
+		ingredient.Vegetable: 1,
+		ingredient.Carb:      2,
+	}
+	sort.Slice(reveal, func(i, j int) bool {
+		ri := roleOrder[reveal[i].Role]
+		rj := roleOrder[reveal[j].Role]
+		if ri != rj {
+			return ri < rj
+		}
+		return reveal[i].Name < reveal[j].Name
+	})
+	remaining := 3
+	t.Events <- DraftOptionsEvent{Reveal: reveal, Picks: remaining}
 	for remaining > 0 && len(reveal) > 0 {
 		act := <-t.Actions
 		sel, ok := act.(DraftSelectionAction)
@@ -57,15 +57,17 @@ func (t *Turn) DraftPhase() {
 }
 
 // DesignPhase allows the player to combine drafted ingredients into named dishes.
-// The player can create multiple dishes until a FinishDesignAction is received.
+// The player can create up to two dishes this turn and may have up to ten dishes
+// overall. The phase ends when a FinishDesignAction is received.
 func (t *Turn) DesignPhase() {
 	t.Events <- PhaseEvent{Turn: t.Number, Phase: PhaseDesign}
 	t.Events <- DesignOptionsEvent{Drafted: t.Player.Drafted}
+	created := 0
 	for {
 		act := <-t.Actions
 		switch a := act.(type) {
 		case CreateDishAction:
-			if len(t.Player.Dishes) >= 2 || a.Name == "" {
+			if a.Name == "" || created >= 2 || len(t.Player.Dishes) >= 10 {
 				continue
 			}
 			used := make(map[int]bool)
@@ -84,6 +86,7 @@ func (t *Turn) DesignPhase() {
 			}
 			d := dish.Dish{Name: a.Name, Ingredients: dishIngs}
 			t.Player.AddDish(d)
+			created++
 			t.Events <- DishCreatedEvent{Dish: d}
 		case FinishDesignAction:
 			return

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -302,29 +302,33 @@ func (d *designMode) Update(m *model, msg tea.Msg) (uiMode, tea.Cmd) {
 					d.confirm = true
 					m.message = "press enter again to confirm"
 				} else {
-                                        name := strings.TrimSpace(d.name.Value())
-                                        if len(d.dishes) >= 2 {
-                                                m.message = "Maximum of 2 dishes reached"
-                                                break
-                                        }
-                                        if len(d.selected) == 0 {
-                                                m.message = "select at least one ingredient to create a dish!"
-                                        } else if name != "" {
-                                                var indices []int
-                                                for i := range d.drafted {
-                                                        if d.selected[i] {
-                                                                indices = append(indices, i)
-                                                        }
-                                                }
-                                                m.actions <- game.CreateDishAction{Name: name, Indices: indices}
-                                                m.message = ""
-                                        } else {
-                                                m.message = ""
-                                        }
-                                        d.confirm = false
-                                }
-                        }
-                case "tab":
+					name := strings.TrimSpace(d.name.Value())
+					if len(m.dishes) >= 10 {
+						m.message = "Maximum of 10 dishes reached"
+						break
+					}
+					if len(d.dishes) >= 2 {
+						m.message = "Maximum of 2 dishes this turn reached"
+						break
+					}
+					if len(d.selected) == 0 {
+						m.message = "select at least one ingredient to create a dish!"
+					} else if name != "" {
+						var indices []int
+						for i := range d.drafted {
+							if d.selected[i] {
+								indices = append(indices, i)
+							}
+						}
+						m.actions <- game.CreateDishAction{Name: name, Indices: indices}
+						m.message = ""
+					} else {
+						m.message = ""
+					}
+					d.confirm = false
+				}
+			}
+		case "tab":
 			d.confirm = false
 			m.message = ""
 			if d.selecting {


### PR DESCRIPTION
## Summary
- let players craft up to two dishes each turn with an overall cap of ten
- display friendly messages when turn or overall dish limits are reached

## Testing
- `go mod tidy`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a0d83f8f24832c9609c8e5a7c8f950