### PR TITLE
Allow drafting five ingredients after first turn

### DIFF
--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -150,7 +150,7 @@ func eventString(e game.Event) string {
 	case game.PhaseEvent:
 		return fmt.Sprintf("Turn %d: %s phase", e.Turn, e.Phase)
 	case game.DraftOptionsEvent:
-		if e.Picks == 3 {
+		if len(e.Reveal) == 10 {
 			return "Draft phase started"
 		}
 		return ""


### PR DESCRIPTION
## Summary
- let players draft five ingredients starting on turn two
- keep draft logs accurate by detecting the start based on the reveal size

## Testing
- `go mod tidy`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a0d84b0d50832c970a12d7750f5057