### PR TITLE
Enable dish deletion and auto-exit on dish limit

### DIFF
--- a/internal/game/events.go
+++ b/internal/game/events.go
@@ -57,6 +57,13 @@ type DishCreatedEvent struct {
 
 func (e DishCreatedEvent) EventType() string { return "dish_created" }
 
+// DishDeletedEvent notifies the UI that a dish has been deleted.
+type DishDeletedEvent struct {
+	Dish dish.Dish
+}
+
+func (e DishDeletedEvent) EventType() string { return "dish_deleted" }
+
 // ServiceResultEvent reports which dish a customer selected.
 // Dish will be nil if no available dish satisfies the customer's cravings.
 type ServiceResultEvent struct {
@@ -92,6 +99,11 @@ type CreateDishAction struct {
 }
 
 func (a CreateDishAction) ActionType() string { return "create_dish" }
+
+// DeleteDishAction removes the most recently created dish.
+type DeleteDishAction struct{}
+
+func (a DeleteDishAction) ActionType() string { return "delete_dish" }
 
 // FinishDesignAction signals that the player is done designing dishes.
 type FinishDesignAction struct{}

--- a/internal/game/turn.go
+++ b/internal/game/turn.go
@@ -91,6 +91,14 @@ func (t *Turn) DesignPhase() {
 			t.Player.AddDish(d)
 			created++
 			t.Events <- DishCreatedEvent{Dish: d}
+		case DeleteDishAction:
+			if created > 0 {
+				d, ok := t.Player.RemoveLastDish()
+				if ok {
+					created--
+					t.Events <- DishDeletedEvent{Dish: d}
+				}
+			}
 		case FinishDesignAction:
 			return
 		}

--- a/internal/player/player.go
+++ b/internal/player/player.go
@@ -27,6 +27,17 @@ func (p *Player) AddDish(d dish.Dish) {
 	p.Dishes = append(p.Dishes, d)
 }
 
+// RemoveLastDish removes and returns the most recently added dish.
+// The second return value is false if there are no dishes to remove.
+func (p *Player) RemoveLastDish() (dish.Dish, bool) {
+	if len(p.Dishes) == 0 {
+		return dish.Dish{}, false
+	}
+	d := p.Dishes[len(p.Dishes)-1]
+	p.Dishes = p.Dishes[:len(p.Dishes)-1]
+	return d, true
+}
+
 // AddMoney increases the player's money by the given amount.
 func (p *Player) AddMoney(amount int) {
 	p.Money += amount

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -65,6 +65,10 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.ingredients = append(m.ingredients, ev.Ingredient)
 		case game.DishCreatedEvent:
 			m.dishes = append(m.dishes, ev.Dish)
+		case game.DishDeletedEvent:
+			if len(m.dishes) > 0 {
+				m.dishes = m.dishes[:len(m.dishes)-1]
+			}
 		case game.ServiceEndEvent:
 			m.ingredients = nil
 		}
@@ -160,6 +164,8 @@ func eventString(e game.Event) string {
 		return "Design phase begins"
 	case game.DishCreatedEvent:
 		return fmt.Sprintf("Dish created: %s", e.Dish.Name)
+	case game.DishDeletedEvent:
+		return fmt.Sprintf("Dish deleted: %s", e.Dish.Name)
 	case game.ServiceResultEvent:
 		dishName := "no dish"
 		if e.Dish != nil {
@@ -271,6 +277,12 @@ func (d *designMode) Update(m *model, msg tea.Msg) (uiMode, tea.Cmd) {
 		d.name.SetValue("")
 		d.selected = make(map[int]bool)
 		d.confirm = false
+	case game.DishDeletedEvent:
+		if len(d.dishes) > 0 {
+			m.message = fmt.Sprintf("Deleted dish '%s'", d.dishes[len(d.dishes)-1])
+			d.dishes = d.dishes[:len(d.dishes)-1]
+		}
+		d.confirm = false
 	case game.ServiceResultEvent:
 		return &serviceMode{current: &msg}, nil
 	case tea.KeyMsg:
@@ -298,19 +310,19 @@ func (d *designMode) Update(m *model, msg tea.Msg) (uiMode, tea.Cmd) {
 					d.selected[d.cursor] = true
 				}
 			} else {
-				if !d.confirm {
+				if len(m.dishes) >= 10 || len(d.dishes) >= 2 {
+					if !d.confirm {
+						d.confirm = true
+						m.message = "dish limit reached. press enter again to finish"
+					} else {
+						m.actions <- game.FinishDesignAction{}
+						return nil, nil
+					}
+				} else if !d.confirm {
 					d.confirm = true
 					m.message = "press enter again to confirm"
 				} else {
 					name := strings.TrimSpace(d.name.Value())
-					if len(m.dishes) >= 10 {
-						m.message = "Maximum of 10 dishes reached"
-						break
-					}
-					if len(d.dishes) >= 2 {
-						m.message = "Maximum of 2 dishes this turn reached"
-						break
-					}
 					if len(d.selected) == 0 {
 						m.message = "select at least one ingredient to create a dish!"
 					} else if name != "" {
@@ -327,6 +339,10 @@ func (d *designMode) Update(m *model, msg tea.Msg) (uiMode, tea.Cmd) {
 					}
 					d.confirm = false
 				}
+			}
+		case "ctrl+d":
+			if len(d.dishes) > 0 {
+				m.actions <- game.DeleteDishAction{}
 			}
 		case "tab":
 			d.confirm = false
@@ -378,7 +394,7 @@ func (d *designMode) View(m *model) string {
 }
 
 func (d *designMode) Status(m *model) string {
-	return "up/down: move • enter: select • tab: name • enter x2: create dish • f: finish • q: quit"
+	return "up/down: move • enter: select • tab: name • enter x2: create dish • ctrl+d: delete • f: finish • q: quit"
 }
 
 // ---- Service Mode ----


### PR DESCRIPTION
## Summary
- allow deleting the most recently created dish during design
- press Enter twice to finish design when dish limit is reached

## Testing
- `go mod tidy`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a0f98df0e0832ca2246f8691ce42b3