### PR TITLE
Highlight dish availability in design phase

### DIFF
--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -107,11 +107,15 @@ func (m *model) View() string {
 		infoBuilder.WriteString("  (none)\n")
 	} else {
 		for _, d := range m.dishes {
-			name := d.Name
-			if !m.hasIngredients(d) {
-				name = missingStyle.Render(name)
+			have, total := m.ingredientCount(d)
+			line := fmt.Sprintf("- %s", d.Name)
+			if have < total {
+				line = fmt.Sprintf("%s (%d/%d)", line, have, total)
+				line = missingStyle.Render(line)
+			} else {
+				line = servedStyle.Render(line)
 			}
-			infoBuilder.WriteString("- " + name + "\n")
+			infoBuilder.WriteString(line + "\n")
 		}
 	}
 	info := paneStyle.Render(infoBuilder.String())
@@ -129,20 +133,22 @@ func (m *model) View() string {
 	return lipgloss.JoinVertical(lipgloss.Left, info, content, status, message)
 }
 
-func (m *model) hasIngredients(d dish.Dish) bool {
+func (m *model) ingredientCount(d dish.Dish) (have, total int) {
+	total = len(d.Ingredients)
 	for _, need := range d.Ingredients {
-		found := false
-		for _, have := range m.ingredients {
-			if have == need {
-				found = true
+		for _, ing := range m.ingredients {
+			if ing == need {
+				have++
 				break
 			}
 		}
-		if !found {
-			return false
-		}
 	}
-	return true
+	return have, total
+}
+
+func (m *model) hasIngredients(d dish.Dish) bool {
+	have, total := m.ingredientCount(d)
+	return have == total
 }
 
 func eventString(e game.Event) string {


### PR DESCRIPTION
## Summary
- Color game info dish list green when all ingredients are available
- Show red dish names with a have/total fraction when ingredients are missing
- Add helper to count how many ingredients a dish requires vs available

## Testing
- `go mod tidy`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a0f9c58c2c832c8cbeca0afdc0b26c