### PR TITLE
Add unit tests with testify

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/charmbracelet/bubbles v0.17.1
 	github.com/charmbracelet/bubbletea v1.3.6
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/stretchr/testify v1.10.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -17,6 +18,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.9.3 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
@@ -25,6 +27,7 @@ require (
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sync v0.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd h1:vy0G
 github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd/go.mod h1:xe0nKWGd3eJgtqZRaN9RjMtK7xUYchjzPr7q6kcvCCs=
 github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQaGIAQ=
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
@@ -34,9 +36,13 @@ github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELU
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc=
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561 h1:MDc5xs78ZrZr3HMQugiXOAkSZtfTpbJLDr/lwfgO53E=

--- a/internal/customer/customer_test.go
+++ b/internal/customer/customer_test.go
@@ -1,0 +1,34 @@
+package customer_test
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"executive-chef/internal/customer"
+	"executive-chef/internal/ingredient"
+)
+
+func TestRandomCravingUniqueness(t *testing.T) {
+	rand.Seed(1)
+	ingredients := []ingredient.Ingredient{
+		{Name: "Chicken", Role: ingredient.Protein},
+		{Name: "Chicken", Role: ingredient.Protein},
+		{Name: "Rice", Role: ingredient.Carb},
+	}
+	cr := customer.RandomCraving(ingredients)
+	require.NotEmpty(t, cr.Ingredients)
+
+	allowed := []ingredient.Ingredient{
+		{Name: "Chicken", Role: ingredient.Protein},
+		{Name: "Rice", Role: ingredient.Carb},
+	}
+	seen := map[ingredient.Ingredient]bool{}
+	for _, ing := range cr.Ingredients {
+		assert.Contains(t, allowed, ing)
+		assert.False(t, seen[ing])
+		seen[ing] = true
+	}
+}

--- a/internal/deck/deck_test.go
+++ b/internal/deck/deck_test.go
@@ -1,0 +1,39 @@
+package deck_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"executive-chef/internal/deck"
+	"executive-chef/internal/ingredient"
+)
+
+func TestNewDeck(t *testing.T) {
+	all := []ingredient.Ingredient{
+		{Name: "Chicken", Role: ingredient.Protein},
+		{Name: "Rice", Role: ingredient.Carb},
+		{Name: "Broccoli", Role: ingredient.Vegetable},
+	}
+	d := deck.New(all)
+	require.NotNil(t, d)
+	assert.Equal(t, 50, len(d.Cards))
+	for _, card := range d.Cards {
+		assert.Contains(t, all, card)
+	}
+}
+
+func TestDraw(t *testing.T) {
+	all := []ingredient.Ingredient{
+		{Name: "Chicken", Role: ingredient.Protein},
+		{Name: "Rice", Role: ingredient.Carb},
+	}
+	d := deck.New(all)
+	drawn := d.Draw(10)
+	assert.Len(t, drawn, 10)
+	assert.Len(t, d.Cards, 40)
+	drawn = d.Draw(100)
+	assert.Len(t, drawn, 40)
+	assert.Empty(t, d.Cards)
+}

--- a/internal/game/turn_test.go
+++ b/internal/game/turn_test.go
@@ -1,0 +1,21 @@
+package game
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"executive-chef/internal/ingredient"
+)
+
+func TestHasIngredients(t *testing.T) {
+	have := []ingredient.Ingredient{
+		{Name: "Chicken", Role: ingredient.Protein},
+		{Name: "Rice", Role: ingredient.Carb},
+	}
+	needed := []ingredient.Ingredient{{Name: "Rice", Role: ingredient.Carb}}
+	assert.True(t, hasIngredients(have, needed))
+
+	needed = append(needed, ingredient.Ingredient{Name: "Broccoli", Role: ingredient.Vegetable})
+	assert.False(t, hasIngredients(have, needed))
+}

--- a/internal/ingredient/ingredient_test.go
+++ b/internal/ingredient/ingredient_test.go
@@ -1,0 +1,32 @@
+package ingredient_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"executive-chef/internal/ingredient"
+)
+
+func TestLoadFromFile(t *testing.T) {
+	data := `- name: Chicken
+  role: Protein
+- name: Rice
+  role: Carb
+`
+	tmpFile, err := os.CreateTemp(t.TempDir(), "ingredients-*.yaml")
+	require.NoError(t, err)
+	_, err = tmpFile.Write([]byte(data))
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+
+	ingredients, err := ingredient.LoadFromFile(tmpFile.Name())
+	require.NoError(t, err)
+	expected := []ingredient.Ingredient{
+		{Name: "Chicken", Role: ingredient.Protein},
+		{Name: "Rice", Role: ingredient.Carb},
+	}
+	assert.Equal(t, expected, ingredients)
+}

--- a/internal/player/player_test.go
+++ b/internal/player/player_test.go
@@ -1,0 +1,34 @@
+package player_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"executive-chef/internal/dish"
+	"executive-chef/internal/ingredient"
+	"executive-chef/internal/player"
+)
+
+func TestPlayerLifecycle(t *testing.T) {
+	p := player.New()
+	require.NotNil(t, p)
+	assert.Empty(t, p.Drafted)
+	assert.Empty(t, p.Dishes)
+	assert.Equal(t, 0, p.Money)
+
+	ing := ingredient.Ingredient{Name: "Chicken", Role: ingredient.Protein}
+	p.Add(ing)
+	assert.Equal(t, []ingredient.Ingredient{ing}, p.Drafted)
+
+	d := dish.Dish{Name: "Chicken Dish", Ingredients: []ingredient.Ingredient{ing}}
+	p.AddDish(d)
+	assert.Equal(t, []dish.Dish{d}, p.Dishes)
+
+	p.AddMoney(5)
+	assert.Equal(t, 5, p.Money)
+
+	p.ResetTurn()
+	assert.Empty(t, p.Drafted)
+}


### PR DESCRIPTION
## Summary
- add testify to dependencies and set up unit tests
- cover ingredient file loading and deck draw logic
- test player operations, game ingredient checks, and customer craving generation

## Testing
- `go mod tidy`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a0f9f336f0832c8dd3ec0eb0b7caca