### PR TITLE
Add customer ingredient constraints

### DIFF
--- a/internal/customer/customer.go
+++ b/internal/customer/customer.go
@@ -16,8 +16,9 @@ type Craving struct {
 
 // Customer represents a single customer with ordered cravings and a name.
 type Customer struct {
-	Name     string
-	Cravings []Craving
+	Name       string
+	Cravings   []Craving
+	Constraint *ingredient.Ingredient // ingredient the customer refuses, nil if none
 }
 
 // RandomCraving returns a Craving made of random ingredients.
@@ -57,7 +58,29 @@ func RandomCustomer(ingredients []ingredient.Ingredient, numCravings int) Custom
 	for i := 0; i < numCravings; i++ {
 		cravings[i] = RandomCraving(ingredients)
 	}
-	return Customer{Name: gofakeit.Name(), Cravings: cravings}
+
+	// Choose a constraint from ingredients not already in cravings with 50% chance.
+	var constraint *ingredient.Ingredient
+	if len(ingredients) > 0 {
+		used := make(map[ingredient.Ingredient]bool)
+		for _, cr := range cravings {
+			for _, ing := range cr.Ingredients {
+				used[ing] = true
+			}
+		}
+		var candidates []ingredient.Ingredient
+		for _, ing := range ingredients {
+			if !used[ing] {
+				candidates = append(candidates, ing)
+			}
+		}
+		if len(candidates) > 0 && rand.Intn(2) == 0 {
+			c := candidates[rand.Intn(len(candidates))]
+			constraint = &c
+		}
+	}
+
+	return Customer{Name: gofakeit.Name(), Cravings: cravings, Constraint: constraint}
 }
 
 // RandomCustomers generates the specified number of customers.

--- a/internal/game/turn.go
+++ b/internal/game/turn.go
@@ -18,7 +18,7 @@ type Turn struct {
 // the player may draft three of them in the first turn and five thereafter.
 func (t *Turn) DraftPhase() {
 	t.Game.Events <- PhaseEvent{Turn: t.Number, Phase: PhaseDraft}
-	reveal := t.Deck.Draw(10)
+	reveal := t.Game.Deck.Draw(10)
 	roleOrder := map[ingredient.Role]int{
 		ingredient.Protein:   0,
 		ingredient.Vegetable: 1,
@@ -113,6 +113,18 @@ func (t *Turn) ServicePhase() {
 		bestScore := 0
 		bestCraving := -1
 		for i, d := range available {
+			if c.Constraint != nil {
+				rejected := false
+				for _, ing := range d.Ingredients {
+					if ing == *c.Constraint {
+						rejected = true
+						break
+					}
+				}
+				if rejected {
+					continue
+				}
+			}
 			score := 0
 			cravingIdx := -1
 			for j, cr := range c.Cravings {

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -455,7 +455,11 @@ func (s *serviceMode) View(m *model) string {
 				craving = append(craving, ing.Name)
 			}
 		}
-		b.WriteString(fmt.Sprintf("%s: %s -> ", s.current.Customer.Name, strings.Join(craving, ", ")))
+		var constraint string
+		if s.current.Customer.Constraint != nil {
+			constraint = fmt.Sprintf(" (no %s)", s.current.Customer.Constraint.Name)
+		}
+		b.WriteString(fmt.Sprintf("%s: %s%s -> ", s.current.Customer.Name, strings.Join(craving, ", "), constraint))
 		if s.current.Dish != nil {
 			b.WriteString(servedStyle.Render(s.current.Dish.Name))
 		} else {


### PR DESCRIPTION
## Summary
- Allow customers to have an optional ingredient constraint they refuse to eat
- Ignore dishes that contain a customer's constraint when serving
- Show the customer's constraint in the service view

## Testing
- `go mod tidy`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a11a0cd3cc832cb6051dccf7f30649