### PR TITLE
Show default dish name when ingredients selected

### DIFF
--- a/internal/game/turn.go
+++ b/internal/game/turn.go
@@ -18,7 +18,7 @@ type Turn struct {
 // the player may draft three of them in the first turn and five thereafter.
 func (t *Turn) DraftPhase() {
 	t.Game.Events <- PhaseEvent{Turn: t.Number, Phase: PhaseDraft}
-	reveal := t.Deck.Draw(10)
+	reveal := t.Game.Deck.Draw(10)
 	roleOrder := map[ingredient.Role]int{
 		ingredient.Protein:   0,
 		ingredient.Vegetable: 1,


### PR DESCRIPTION
## Summary
- auto-populate dish name based on selected ingredients
- track auto-generated names so manual edits are preserved
- fix Turn draft phase to use game's deck

## Testing
- `go mod tidy`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a11ac9e148832c8a0a827514f7060e