### PR TITLE
Limit cravings to three ingredients

### DIFF
--- a/internal/customer/customer.go
+++ b/internal/customer/customer.go
@@ -22,7 +22,8 @@ type Customer struct {
 
 // RandomCraving returns a Craving made of random ingredients.
 // Each ingredient in the resulting craving will be unique even if the
-// provided slice contains duplicates.
+// provided slice contains duplicates, and no craving will contain more than
+// three ingredients.
 func RandomCraving(ingredients []ingredient.Ingredient) Craving {
 	if len(ingredients) == 0 {
 		return Craving{}
@@ -38,7 +39,11 @@ func RandomCraving(ingredients []ingredient.Ingredient) Craving {
 		}
 	}
 
-	n := rand.Intn(len(unique)) + 1
+	limit := len(unique)
+	if limit > 3 {
+		limit = 3
+	}
+	n := rand.Intn(limit) + 1
 	idxs := rand.Perm(len(unique))[:n]
 	combo := make([]ingredient.Ingredient, 0, n)
 	for _, i := range idxs {

--- a/internal/customer/customer_test.go
+++ b/internal/customer/customer_test.go
@@ -32,3 +32,17 @@ func TestRandomCravingUniqueness(t *testing.T) {
 		seen[ing] = true
 	}
 }
+
+func TestRandomCravingMaxSize(t *testing.T) {
+	rand.Seed(2)
+	ingredients := []ingredient.Ingredient{
+		{Name: "Chicken", Role: ingredient.Protein},
+		{Name: "Beef", Role: ingredient.Protein},
+		{Name: "Rice", Role: ingredient.Carb},
+		{Name: "Pasta", Role: ingredient.Carb},
+		{Name: "Lettuce", Role: ingredient.Vegetable},
+	}
+	cr := customer.RandomCraving(ingredients)
+	require.NotEmpty(t, cr.Ingredients)
+	assert.LessOrEqual(t, len(cr.Ingredients), 3)
+}


### PR DESCRIPTION
## Summary
- restrict random cravings to a maximum of three unique ingredients
- test that RandomCraving never returns more than three ingredients

## Testing
- `go mod tidy`
- `go build ./...` *(fails: internal/game/turn.go:21:14: t.Deck undefined)*
- `go test ./...` *(fails: internal/game/turn.go:21:14: t.Deck undefined)*
- `go test ./internal/customer -run .`


------
https://chatgpt.com/codex/tasks/task_e_68a11ae5ddec832cbcd28f9bba9ff37e