### PR TITLE
Enable dish selection and deletion via double D key

### DIFF
--- a/internal/game/events.go
+++ b/internal/game/events.go
@@ -59,7 +59,8 @@ func (e DishCreatedEvent) EventType() string { return "dish_created" }
 
 // DishDeletedEvent notifies the UI that a dish has been deleted.
 type DishDeletedEvent struct {
-	Dish dish.Dish
+	Dish  dish.Dish
+	Index int
 }
 
 func (e DishDeletedEvent) EventType() string { return "dish_deleted" }
@@ -100,8 +101,10 @@ type CreateDishAction struct {
 
 func (a CreateDishAction) ActionType() string { return "create_dish" }
 
-// DeleteDishAction removes the most recently created dish.
-type DeleteDishAction struct{}
+// DeleteDishAction removes a dish at the specified index.
+type DeleteDishAction struct {
+	Index int
+}
 
 func (a DeleteDishAction) ActionType() string { return "delete_dish" }
 

--- a/internal/game/turn.go
+++ b/internal/game/turn.go
@@ -57,6 +57,7 @@ func (t *Turn) DraftPhase() {
 func (t *Turn) DesignPhase() {
 	t.Game.Events <- PhaseEvent{Turn: t.Number, Phase: PhaseDesign}
 	t.Game.Events <- DesignOptionsEvent{Drafted: t.Game.Player.Drafted}
+	existing := len(t.Game.Player.Dishes)
 	created := 0
 
 	for {
@@ -85,11 +86,13 @@ func (t *Turn) DesignPhase() {
 			created++
 			t.Game.Events <- DishCreatedEvent{Dish: d}
 		case DeleteDishAction:
-			if created > 0 {
-				d, ok := t.Game.Player.RemoveLastDish()
+			if a.Index >= 0 && a.Index < len(t.Game.Player.Dishes) {
+				d, ok := t.Game.Player.RemoveDish(a.Index)
 				if ok {
-					created--
-					t.Game.Events <- DishDeletedEvent{Dish: d}
+					if a.Index >= existing && created > 0 {
+						created--
+					}
+					t.Game.Events <- DishDeletedEvent{Dish: d, Index: a.Index}
 				}
 			}
 		case FinishDesignAction:

--- a/internal/player/player.go
+++ b/internal/player/player.go
@@ -38,6 +38,17 @@ func (p *Player) RemoveLastDish() (dish.Dish, bool) {
 	return d, true
 }
 
+// RemoveDish removes and returns the dish at the given index.
+// The second return value is false if the index is out of range.
+func (p *Player) RemoveDish(i int) (dish.Dish, bool) {
+	if i < 0 || i >= len(p.Dishes) {
+		return dish.Dish{}, false
+	}
+	d := p.Dishes[i]
+	p.Dishes = append(p.Dishes[:i], p.Dishes[i+1:]...)
+	return d, true
+}
+
 // AddMoney increases the player's money by the given amount.
 func (p *Player) AddMoney(amount int) {
 	p.Money += amount


### PR DESCRIPTION
## Summary
- Cycle design focus through ingredients, name entry, and dish selection with Tab
- Delete chosen dish by pressing `D` twice with confirmation prompt
- Track dish deletion by index across game state

## Testing
- `go mod tidy`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a11c424bd4832cb60667267d8dbb79