### PR TITLE
Allow drafting five ingredients after first turn

### DIFF
--- a/internal/game/turn.go
+++ b/internal/game/turn.go
@@ -33,6 +33,9 @@ func (t *Turn) DraftPhase() {
 		return reveal[i].Name < reveal[j].Name
 	})
 	remaining := 3
+	if t.Number > 1 {
+		remaining = 5
+	}
 	t.Game.Events <- DraftOptionsEvent{Reveal: reveal, Picks: remaining}
 	for remaining > 0 && len(reveal) > 0 {
 		act := <-t.Game.Actions

--- a/internal/game/turn_test.go
+++ b/internal/game/turn_test.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"executive-chef/internal/deck"
 	"executive-chef/internal/ingredient"
+	"executive-chef/internal/player"
 )
 
 func TestHasIngredients(t *testing.T) {
@@ -18,4 +20,30 @@ func TestHasIngredients(t *testing.T) {
 
 	needed = append(needed, ingredient.Ingredient{Name: "Broccoli", Role: ingredient.Vegetable})
 	assert.False(t, hasIngredients(have, needed))
+}
+
+func TestDraftPhaseAllowsFivePicksAfterFirstTurn(t *testing.T) {
+	reveal := []ingredient.Ingredient{
+		{Name: "Ing1", Role: ingredient.Protein},
+		{Name: "Ing2", Role: ingredient.Protein},
+		{Name: "Ing3", Role: ingredient.Protein},
+		{Name: "Ing4", Role: ingredient.Protein},
+		{Name: "Ing5", Role: ingredient.Protein},
+		{Name: "Ing6", Role: ingredient.Protein},
+		{Name: "Ing7", Role: ingredient.Protein},
+		{Name: "Ing8", Role: ingredient.Protein},
+		{Name: "Ing9", Role: ingredient.Protein},
+		{Name: "Ing10", Role: ingredient.Protein},
+	}
+	d := &deck.Deck{Cards: reveal}
+	p := player.New()
+	events := make(chan Event, 20)
+	actions := make(chan Action, 5)
+	for i := 0; i < 5; i++ {
+		actions <- DraftSelectionAction{Index: 0}
+	}
+	g := New(nil, d, p, events, actions)
+	turn := Turn{Number: 2, Game: g}
+	turn.DraftPhase()
+	assert.Len(t, p.Drafted, 5)
 }


### PR DESCRIPTION
## Summary
- Let the draft phase grant five ingredient picks on turns after the first
- Add a unit test ensuring later turns allow drafting five ingredients

## Testing
- `go mod tidy`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a11ea4bf00832c84850721d3bc9758