### PR TITLE
Use customer deck to serve patrons per turn

### DIFF
--- a/internal/customer/deck.go
+++ b/internal/customer/deck.go
@@ -1,0 +1,31 @@
+package customer
+
+import (
+	"math/rand"
+
+	"executive-chef/internal/ingredient"
+)
+
+// Deck represents a collection of customer cards.
+type Deck struct {
+	Cards []Customer
+}
+
+// NewDeck creates a deck containing 15 random customers.
+// Customers are shuffled upon creation.
+func NewDeck(ingredients []ingredient.Ingredient) *Deck {
+	cards := RandomCustomers(ingredients, 15)
+	rand.Shuffle(len(cards), func(i, j int) { cards[i], cards[j] = cards[j], cards[i] })
+	return &Deck{Cards: cards}
+}
+
+// Draw removes up to n customers from the top of the deck and returns them.
+func (d *Deck) Draw(n int) []Customer {
+	if n > len(d.Cards) {
+		n = len(d.Cards)
+	}
+	drawn := make([]Customer, n)
+	copy(drawn, d.Cards[:n])
+	d.Cards = d.Cards[n:]
+	return drawn
+}

--- a/internal/customer/deck_test.go
+++ b/internal/customer/deck_test.go
@@ -1,0 +1,26 @@
+package customer_test
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v7"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"executive-chef/internal/customer"
+	"executive-chef/internal/ingredient"
+)
+
+func TestDeckDraw(t *testing.T) {
+	rand.Seed(1)
+	gofakeit.Seed(1)
+	ingredients := []ingredient.Ingredient{
+		{Name: "Chicken", Role: ingredient.Protein},
+	}
+	d := customer.NewDeck(ingredients)
+	require.Len(t, d.Cards, 15)
+	drawn := d.Draw(3)
+	assert.Len(t, drawn, 3)
+	assert.Len(t, d.Cards, 12)
+}

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -1,21 +1,21 @@
 package game
 
 import (
+	"executive-chef/internal/customer"
 	"executive-chef/internal/deck"
-	"executive-chef/internal/ingredient"
 	"executive-chef/internal/player"
 )
 
 type Game struct {
-	Deck           *deck.Deck
-	Player         *player.Player
-	Events         chan<- Event
-	Actions        <-chan Action
-	AllIngredients []ingredient.Ingredient
+	Deck      *deck.Deck
+	Customers *customer.Deck
+	Player    *player.Player
+	Events    chan<- Event
+	Actions   <-chan Action
 }
 
-func New(all []ingredient.Ingredient, d *deck.Deck, p *player.Player, events chan<- Event, actions <-chan Action) *Game {
-	return &Game{AllIngredients: all, Deck: d, Player: p, Events: events, Actions: actions}
+func New(d *deck.Deck, c *customer.Deck, p *player.Player, events chan<- Event, actions <-chan Action) *Game {
+	return &Game{Deck: d, Customers: c, Player: p, Events: events, Actions: actions}
 }
 
 func (g *Game) Play() {

--- a/internal/game/turn.go
+++ b/internal/game/turn.go
@@ -3,7 +3,6 @@ package game
 import (
 	"sort"
 
-	"executive-chef/internal/customer"
 	"executive-chef/internal/dish"
 	"executive-chef/internal/ingredient"
 )
@@ -101,7 +100,7 @@ func (t *Turn) DesignPhase() {
 // ServicePhase presents dishes to customers who choose based on their cravings.
 func (t *Turn) ServicePhase() {
 	t.Game.Events <- PhaseEvent{Turn: t.Number, Phase: PhaseService}
-	customers := customer.RandomCustomers(t.Game.AllIngredients, 3)
+	customers := t.Game.Customers.Draw(3)
 	var available []dish.Dish
 	for _, d := range t.Game.Player.Dishes {
 		if hasIngredients(t.Game.Player.Drafted, d.Ingredients) {

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 
+	"executive-chef/internal/customer"
 	"executive-chef/internal/deck"
 	"executive-chef/internal/game"
 	"executive-chef/internal/ingredient"
@@ -17,12 +18,13 @@ func main() {
 	}
 
 	d := deck.New(ingredients)
+	c := customer.NewDeck(ingredients)
 	p := player.New()
 
 	events := make(chan game.Event)
 	actions := make(chan game.Action)
 
-	g := game.New(ingredients, d, p, events, actions)
+	g := game.New(d, c, p, events, actions)
 
 	go g.Play()
 


### PR DESCRIPTION
## Summary
- Add customer deck type to draw a preset queue of customers each turn
- Update game and main wiring to use the customer deck in service phase
- Include unit test for customer deck draw behavior

## Testing
- `go mod tidy`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a11f1759d4832ca0de4c5ae4554a93