### PR TITLE
Add vegetable-only salad naming

### DIFF
--- a/internal/ui/default_dish_name_test.go
+++ b/internal/ui/default_dish_name_test.go
@@ -1,0 +1,33 @@
+package ui
+
+import (
+	"testing"
+
+	"executive-chef/internal/ingredient"
+)
+
+func TestDefaultDishNameVegetableSalad(t *testing.T) {
+	drafted := []ingredient.Ingredient{
+		{Name: "Lettuce", Role: ingredient.Vegetable},
+		{Name: "Tomato", Role: ingredient.Vegetable},
+	}
+	selected := map[int]bool{0: true, 1: true}
+	got := defaultDishName(selected, drafted)
+	want := "Lettuce Salad"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestDefaultDishNameNonVegetable(t *testing.T) {
+	drafted := []ingredient.Ingredient{
+		{Name: "Chicken", Role: ingredient.Protein},
+		{Name: "Rice", Role: ingredient.Carb},
+	}
+	selected := map[int]bool{0: true, 1: true}
+	got := defaultDishName(selected, drafted)
+	want := "Chicken and Rice"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -483,13 +483,21 @@ func (d *designMode) Status(m *model) string {
 
 func defaultDishName(selected map[int]bool, drafted []ingredient.Ingredient) string {
 	var names []string
+	allVegetables := true
+	count := 0
 	for i := range drafted {
 		if selected[i] {
-			names = append(names, drafted[i].Name)
-			if len(names) == 2 {
-				break
+			if drafted[i].Role != ingredient.Vegetable {
+				allVegetables = false
+			}
+			count++
+			if len(names) < 2 {
+				names = append(names, drafted[i].Name)
 			}
 		}
+	}
+	if count > 1 && allVegetables {
+		return names[0] + " Salad"
 	}
 	switch len(names) {
 	case 2:


### PR DESCRIPTION
## Summary
- add salad naming when all selected ingredients are vegetables
- test default dish naming logic for salad and non-salad cases

## Testing
- `go mod tidy`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a13c8eddd4832cb072bd6e386b4db5