### PR TITLE
Enable finishing design from dishes tab

### DIFF
--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -433,7 +433,7 @@ func (d *designMode) Update(m *model, msg tea.Msg) (uiMode, tea.Cmd) {
 				d.name.Blur()
 			}
 		case "f", "F":
-			if d.focus == focusIngredients {
+			if d.focus == focusIngredients || d.focus == focusDishes {
 				m.message = ""
 				m.actions <- game.FinishDesignAction{}
 				return nil, nil


### PR DESCRIPTION
## Summary
- Allow pressing `f` in the design phase's dishes tab to finish designing

## Testing
- `go mod tidy`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a13d3f7234832c86b90315c8d7ae67