### PR TITLE
Display all customer cravings in service view

### DIFF
--- a/internal/ui/service_mode_test.go
+++ b/internal/ui/service_mode_test.go
@@ -1,0 +1,51 @@
+package ui
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"executive-chef/internal/customer"
+	"executive-chef/internal/dish"
+	"executive-chef/internal/game"
+	"executive-chef/internal/ingredient"
+)
+
+func stripANSI(s string) string {
+	re := regexp.MustCompile("\x1b\\[[0-9;]*m")
+	return re.ReplaceAllString(s, "")
+}
+
+func TestServiceModeViewShowsAllCravings(t *testing.T) {
+	c := customer.Customer{
+		Name: "Alice",
+		Cravings: []customer.Craving{
+			{Ingredients: []ingredient.Ingredient{
+				{Name: "Lettuce", Role: ingredient.Vegetable},
+				{Name: "Tomato", Role: ingredient.Vegetable},
+			}},
+			{Ingredients: []ingredient.Ingredient{
+				{Name: "Tomato", Role: ingredient.Vegetable},
+				{Name: "Cheese", Role: ingredient.Protein},
+			}},
+		},
+	}
+	d := &dish.Dish{
+		Name: "Salad",
+		Ingredients: []ingredient.Ingredient{
+			{Name: "Tomato", Role: ingredient.Vegetable},
+			{Name: "Cheese", Role: ingredient.Protein},
+		},
+	}
+	sm := serviceMode{current: &game.ServiceResultEvent{Customer: c, Dish: d, Payment: 3}}
+	out := stripANSI(sm.View(&model{}))
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	require.Equal(t, 4, len(lines))
+	assert.Equal(t, "Service", strings.TrimSpace(lines[0]))
+	assert.Equal(t, "Alice", strings.TrimSpace(lines[1]))
+	assert.Equal(t, "Lettuce, Tomato", strings.TrimSpace(lines[2]))
+	assert.Equal(t, "Tomato, Cheese -> Salad ($3)", strings.TrimSpace(lines[3]))
+}

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -534,11 +534,39 @@ func (s *serviceMode) View(m *model) string {
 	var b strings.Builder
 	b.WriteString(titleStyle.Render("Service") + "\n")
 	if s.current != nil {
-		var craving []string
-		if len(s.current.Customer.Cravings) > 0 {
-			for _, ing := range s.current.Customer.Cravings[0].Ingredients {
+		var constraint string
+		if s.current.Customer.Constraint != nil {
+			constraint = fmt.Sprintf(" (no %s)", s.current.Customer.Constraint.Name)
+		}
+
+		// Determine which craving was fulfilled by the served dish.
+		fulfilled := 0
+		bestScore := 0
+		if s.current.Dish != nil {
+			fulfilled = -1
+			for i, cr := range s.current.Customer.Cravings {
+				score := 0
+				for _, ing := range cr.Ingredients {
+					for _, ding := range s.current.Dish.Ingredients {
+						if ding == ing {
+							score++
+							break
+						}
+					}
+				}
+				if score > bestScore {
+					bestScore = score
+					fulfilled = i
+				}
+			}
+		}
+
+		b.WriteString(fmt.Sprintf("%s%s\n", s.current.Customer.Name, constraint))
+		for i, cr := range s.current.Customer.Cravings {
+			var craving []string
+			for _, ing := range cr.Ingredients {
 				name := ing.Name
-				if s.current.Dish != nil {
+				if i == fulfilled && s.current.Dish != nil {
 					for _, ding := range s.current.Dish.Ingredients {
 						if ding == ing {
 							name = servedStyle.Render(name)
@@ -548,21 +576,19 @@ func (s *serviceMode) View(m *model) string {
 				}
 				craving = append(craving, name)
 			}
+			b.WriteString(strings.Join(craving, ", "))
+			if i == fulfilled {
+				if s.current.Dish != nil {
+					b.WriteString(" -> " + servedStyle.Render(s.current.Dish.Name))
+				} else {
+					b.WriteString(" -> " + missingStyle.Render("no dish"))
+				}
+				if s.current.Payment > 0 {
+					b.WriteString(fmt.Sprintf(" ($%d)", s.current.Payment))
+				}
+			}
+			b.WriteString("\n")
 		}
-		var constraint string
-		if s.current.Customer.Constraint != nil {
-			constraint = fmt.Sprintf(" (no %s)", s.current.Customer.Constraint.Name)
-		}
-		b.WriteString(fmt.Sprintf("%s: %s%s -> ", s.current.Customer.Name, strings.Join(craving, ", "), constraint))
-		if s.current.Dish != nil {
-			b.WriteString(servedStyle.Render(s.current.Dish.Name))
-		} else {
-			b.WriteString(missingStyle.Render("no dish"))
-		}
-		if s.current.Payment > 0 {
-			b.WriteString(fmt.Sprintf(" ($%d)", s.current.Payment))
-		}
-		b.WriteString("\n")
 	}
 	return paneStyle.Render(b.String())
 }


### PR DESCRIPTION
## Summary
- Render every craving for a customer on its own line during service
- Highlight the dish ordered alongside the fulfilled craving
- Test service view to ensure all cravings and dish display correctly

## Testing
- `go mod tidy`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a13c252b70832c846bfd2c0fe65979